### PR TITLE
Adding message function support

### DIFF
--- a/build/validator.js
+++ b/build/validator.js
@@ -42,7 +42,7 @@ exports['default'] = function (options) {
                     if (!flag) {
                         errorParam = key;
                         errorId = id;
-                        errorMsg = msg || '';
+                        errorMsg = (typeof msg === 'function' ? msg(param, store.getState(), action.payload) : msg) || '';
                     }
 
                     return flag;

--- a/src/validator.babel
+++ b/src/validator.babel
@@ -32,7 +32,10 @@ export default function(options) {
             if(!flag) {
                 errorParam = key;
                 errorId = id;
-                errorMsg = msg || '';
+                errorMsg = (typeof msg === 'function' 
+                            ? msg(param, store.getState(), action.payload) 
+                            : msg)
+                            || '';
             }
 
             return flag;

--- a/test/spec.babel
+++ b/test/spec.babel
@@ -424,6 +424,29 @@ describe('redux-validator', () => {
         }
         expect(msg).to.be('validator func must return boolean type');
     });
+    it('message function', () => {
+        const dispatch = finalCreateStoreWithDefaultKey(Reducer).dispatch;
+        const action1 = {
+            type: 'action1',
+            payload: -1,
+            meta: {
+                validator: {
+                    payload: {
+                        func: payload => payload === 1,
+                        msg: payload => 'expected 1, got ' + payload
+                    }
+                }
+            }
+        };
+
+        let result1 = dispatch(action1);
+        expect(result1).to.eql({
+            err: 'validator',
+            msg: 'expected 1, got -1',
+            id: 0,
+            param: 'payload'
+        });
+    });
     it('no param', () => {
         const dispatch = finalCreateStoreWithDefaultKey(Reducer).dispatch;
         const action2 = {


### PR DESCRIPTION
Hi. I made [an issue](https://github.com/MaxLi1994/redux-validator/issues/5) for this earlier, but now I am back with a PR that adds support for `msg` being a function that uses the same arguments as `func`.

Thank you for consideration.